### PR TITLE
Nested buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,38 @@ AUTHOR:
 
 ![List all items](assets/viewbucket.gif)
 
+#### Nested buckets
+
+You can easily list all items in a nested bucket:
+```
+$ bolter -f my.db
++-----------+
+|  BUCKETS  |
++-----------+
+|   root    |
++-----------+
+
+$ bolter -f my.db -b root
+Bucket: root
++---------+---------+
+|   KEY   |  VALUE  |
++---------+---------+
+| nested* |         |
++---------+---------+
+```
+
+***** means `nested` is a bucket.
+
+```
+$ bolter -f my.db -b root.nested
+Bucket: root.nested
++---------+---------+
+|   KEY   |  VALUE  |
++---------+---------+
+|  mykey  | myvalue |
++---------+---------+
+```
+
 ## Contribute
 
 Feel free to ask questions, post issues and open pull requests. My only requirement is that you run `gofmt` on your code before you send in a PR.

--- a/bolter.go
+++ b/bolter.go
@@ -108,6 +108,9 @@ func (i *impl) listBucketItems(bucket string) {
 		}
 		c := b.Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if v == nil {
+				k = append(k, byte('*'))
+			}
 			items = append(items, item{Key: string(k), Value: string(v)})
 		}
 		return nil

--- a/bolter.go
+++ b/bolter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/boltdb/bolt"
 	"github.com/codegangsta/cli"
@@ -94,7 +95,17 @@ func (i *impl) initDB(file string) {
 func (i *impl) listBucketItems(bucket string) {
 	items := []item{}
 	err := i.DB.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(bucket))
+		nbs := strings.Split(bucket, ".")
+		b := tx.Bucket([]byte(nbs[0]))
+		if b == nil {
+			return nil
+		}
+		for _, nb := range nbs[1:] {
+			b = b.Bucket([]byte(nb))
+			if b == nil {
+				return nil
+			}
+		}
 		c := b.Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			items = append(items, item{Key: string(k), Value: string(v)})


### PR DESCRIPTION
Hi,

This PR allows bolter to easily handle nested buckets. 
By example:

List all the buckets:
```
$ bolter -f my.db
+-----------+
|  BUCKETS  |
+-----------+
| templates |
+-----------+
```
List the items of templates:
```
$ bolter -f my.db -b templates
Bucket: templates
+---------+---------+
|   KEY   |  VALUE  |
+---------+---------+
| files   |         |
+---------+---------+
```
List the items of files:
```
$ bolter -f my.db -b templates.files
Bucket: templates.files
+---------+---------+
|   KEY   |  VALUE  |
+---------+---------+
| storage | default |
+---------+---------+
```