### PR TITLE
Machine friendly output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ $ go get -u github.com/hasit/bolter
 $ bolter [global options]
 
 GLOBAL OPTIONS:
-  --file FILE, -f FILE		boltdb FILE to view
-  --bucket BUCKET, -b BUCKET	boltdb BUCKET to view
-  --help, -h			show help
-  --version, -v			print the version
+  --file FILE, -f FILE        boltdb FILE to view
+  --bucket BUCKET, -b BUCKET  boltdb BUCKET to view
+  --machine, -m               key=value format
+  --help, -h                  show help
+  --version, -v               print the version
 ```
 
 ### List all buckets

--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ Bucket: root.nested
 +---------+---------+
 ```
 
+### Machine friendly output
+
+```
+$ bolter -f emails.db -m
+john@doe.com
+jane@roe.com
+sample@example.com
+test@test.com
+
+$ bolter -f emails.db -b john@doe.com -m
+emailLastSent=
+subLocation=
+subTag=
+userActive=true
+userCreatedOn=2016-10-28 07:21:49
+userEmail=john@doe.com
+userFirstName=John
+userLastName=Doe
+nested-bucket*=
+```
+
 ## Contribute
 
 Feel free to ask questions, post issues and open pull requests. My only requirement is that you run `gofmt` on your code before you send in a PR.

--- a/bolter.go
+++ b/bolter.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	var file string
 	var bucket string
-	i := impl{}
+	var machineFriendly bool
 
 	cli.AppHelpTemplate = `NAME:
   {{.Name}} - {{.Usage}}
@@ -48,30 +48,48 @@ AUTHOR:
 			Usage:       "boltdb `BUCKET` to view",
 			Destination: &bucket,
 		},
+		cli.BoolFlag{
+			Name:        "machine-friendly, m",
+			Usage:       "key=value format",
+			Destination: &machineFriendly,
+		},
 	}
 	app.Action = func(c *cli.Context) error {
-		if file != "" {
-			if _, err := os.Stat(file); os.IsNotExist(err) {
-				log.Fatal(err)
-				return err
-			}
-			i.initDB(file)
-			defer i.DB.Close()
-			if bucket != "" {
-				i.listBucketItems(bucket)
-			} else {
-				i.listBuckets()
-			}
-		} else {
+		if file == "" {
 			cli.ShowAppHelp(c)
+			return nil
+		}
+
+		var i impl
+		if machineFriendly {
+			i = impl{fmt: &machineFormatter{}}
+		} else {
+			i = impl{fmt: &tableFormatter{}}
+		}
+		if _, err := os.Stat(file); os.IsNotExist(err) {
+			log.Fatal(err)
+			return err
+		}
+		i.initDB(file)
+		defer i.DB.Close()
+		if bucket != "" {
+			i.listBucketItems(bucket)
+		} else {
+			i.listBuckets()
 		}
 		return nil
 	}
 	app.Run(os.Args)
 }
 
+type formatter interface {
+	DumpBuckets([]bucket)
+	DumpBucketItems(string, []item)
+}
+
 type impl struct {
-	DB *bolt.DB
+	DB  *bolt.DB
+	fmt formatter
 }
 
 type item struct {
@@ -121,14 +139,7 @@ func (i *impl) listBucketItems(bucket string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Bucket: %s\n", bucket)
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Key", "Value"})
-	for _, item := range items {
-		row := []string{item.Key, item.Value}
-		table.Append(row)
-	}
-	table.Render()
+	i.fmt.DumpBucketItems(bucket, items)
 }
 
 func (i *impl) listBuckets() {
@@ -142,6 +153,12 @@ func (i *impl) listBuckets() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	i.fmt.DumpBuckets(buckets)
+}
+
+type tableFormatter struct{}
+
+func (tf tableFormatter) DumpBuckets(buckets []bucket) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Buckets"})
 	for _, b := range buckets {
@@ -149,4 +166,29 @@ func (i *impl) listBuckets() {
 		table.Append(row)
 	}
 	table.Render()
+}
+
+func (tf tableFormatter) DumpBucketItems(bucket string, items []item) {
+	fmt.Printf("Bucket: %s\n", bucket)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Key", "Value"})
+	for _, item := range items {
+		row := []string{item.Key, item.Value}
+		table.Append(row)
+	}
+	table.Render()
+}
+
+type machineFormatter struct{}
+
+func (mf machineFormatter) DumpBuckets(buckets []bucket) {
+	for _, b := range buckets {
+		fmt.Println(b.Name)
+	}
+}
+
+func (mf machineFormatter) DumpBucketItems(_ string, items []item) {
+	for _, item := range items {
+		fmt.Printf("%s=%s\n", item.Key, item.Value)
+	}
 }

--- a/bolter.go
+++ b/bolter.go
@@ -49,7 +49,7 @@ AUTHOR:
 			Destination: &bucket,
 		},
 		cli.BoolFlag{
-			Name:        "machine-friendly, m",
+			Name:        "machine, m",
 			Usage:       "key=value format",
 			Destination: &machineFriendly,
 		},


### PR DESCRIPTION
Hi @hasit 

I need to retrieve values from a boltdb file and the table format makes that difficult.
So I add a `-m` flag, that allows `bolter` to use a `key=value` format instead of tables.

Example:
```
$ bolter -f emails.db -m
john@doe.com
jane@roe.com
sample@example.com
test@test.com

$ bolter -f emails.db -b john@doe.com -m
emailLastSent=
subLocation=
subTag=
userActive=true
userCreatedOn=2016-10-28 07:21:49
userEmail=john@doe.com
userFirstName=John
userLastName=Doe
nested-bucket*=
```

That way it's easier to use `bolter` in shell scripts.