### PR TITLE
cli flags now take pointers instead of structs

### DIFF
--- a/bolter.go
+++ b/bolter.go
@@ -40,15 +40,15 @@ COPYRIGHT:
 	app.Name = "bolter"
 	app.Usage = "view boltdb file interactively in your terminal"
 	app.Version = "2.0.1"
-	app.Authors = []cli.Author{
-	  cli.Author{
-	    Name:  "Hasit Mistry",
-	    Email: "hasitnm@gmail.com",
-	  },
+	app.Authors = []*cli.Author{
+		&cli.Author{
+			Name:  "Hasit Mistry",
+			Email: "hasitnm@gmail.com",
+		},
 	}
 	app.Copyright = "(c) 2016 Hasit Mistry"
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:        "file, f",
 			Usage:       "boltdb `FILE` to view",
 			Destination: &file,


### PR DESCRIPTION
Apparently, this is due to a breaking change in the upstream "github.com/urfave/cli" package.