### PR TITLE
improves for moderate-size databases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/olekukonko/tablewriter v0.0.2
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/urfave/cli v1.22.1
+	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,5 +23,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
+golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/less_wrap_formatter.go
+++ b/less_wrap_formatter.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"io"
+	"os/exec"
+)
+
+type moreWrapFormatter struct {
+	formatter formatter
+}
+
+func (mf moreWrapFormatter) wrapDump(w io.Writer, dump func(io.Writer)) {
+	lessCmd := exec.Command("more")
+	pipeR, pipeW := io.Pipe()
+	go func() {
+		dump(pipeW)
+		pipeW.Close()
+	}()
+	lessCmd.Stdin = pipeR
+	lessCmd.Stdout = w
+	lessCmd.Run()
+}
+
+func (mf moreWrapFormatter) DumpBuckets(w io.Writer, buckets []bucket) {
+	mf.wrapDump(w, func(w io.Writer) {
+		mf.formatter.DumpBuckets(w, buckets)
+	})
+}
+
+func (mf moreWrapFormatter) DumpBucketItems(w io.Writer, bucket string, items []item) {
+	mf.wrapDump(w, func(w io.Writer) {
+		mf.formatter.DumpBucketItems(w, bucket, items)
+	})
+}

--- a/table_formatter.go
+++ b/table_formatter.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+type tableFormatter struct {
+	noValues bool
+}
+
+func (tf tableFormatter) DumpBuckets(w io.Writer, buckets []bucket) {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader([]string{"Buckets"})
+	for _, b := range buckets {
+		row := []string{b.Name}
+		table.Append(row)
+	}
+	table.Render()
+}
+
+func (tf tableFormatter) DumpBucketItems(w io.Writer, bucket string, items []item) {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader([]string{"Key", "Value"})
+	for _, item := range items {
+		var row []string
+		if tf.noValues {
+			row = []string{item.Key, ""}
+		} else {
+			row = []string{item.Key, item.Value}
+		}
+		table.Append(row)
+	}
+	table.Render()
+}


### PR DESCRIPTION
Thanks for the tool! I found it hard to use with database of moderate size. Added two features.

1. `--no-values` cli option to not print values. For the case when values are huge or not readable (gzipped for example). This speeds up a lot in my case,
2. `--more` mode. I have thousand of keys, and can't see the start of the list in terminal 😅. Made something similar to psql, where big listing will print in `less` of `more` mode. Not sure of a right way to do it, used os/exec here, works fine.

Both are ali options and disabled by default. Nothing should change without them.