### PR TITLE
fix: cli.Author is no longer a pointer

### DIFF
--- a/bolter.go
+++ b/bolter.go
@@ -40,8 +40,8 @@ COPYRIGHT:
 	app.Name = "bolter"
 	app.Usage = "view boltdb file interactively in your terminal"
 	app.Version = "2.0.1"
-	app.Authors = []*cli.Author{
-		&cli.Author{
+	app.Authors = []cli.Author{
+		cli.Author{
 			Name:  "Hasit Mistry",
 			Email: "hasitnm@gmail.com",
 		},


### PR DESCRIPTION
fixes cannot use []*cli.Author literal (type []*cli.Author) as type []cli.Author in assignment