### PR TITLE
Fix go authors assignment

### DIFF
--- a/bolter.go
+++ b/bolter.go
@@ -40,8 +40,8 @@ COPYRIGHT:
 	app.Name = "bolter"
 	app.Usage = "view boltdb file interactively in your terminal"
 	app.Version = "2.0.1"
-	app.Authors = []cli.Author{
-		cli.Author{
+	app.Authors = []*cli.Author{
+		&cli.Author{
 			Name:  "Hasit Mistry",
 			Email: "hasitnm@gmail.com",
 		},


### PR DESCRIPTION
```
rvn@moa:~$ go get -u github.com/hasit/bolter
# github.com/hasit/bolter
go/src/github.com/hasit/bolter/bolter.go:43:14: cannot use []cli.Author literal (type []cli.Author) as type []*cli.Author in assignment
rvn@moa:~$ go install github.com/hasit/bolter
# github.com/hasit/bolter
go/src/github.com/hasit/bolter/bolter.go:43:14: cannot use []cli.Author literal (type []cli.Author) as type []*cli.Author in assignment
```

After applying this MR:

```
rvn@moa:~$ go install github.com/hasit/bolter
rvn@moa:~$ ~/go/bin/bolter 
NAME:
  bolter - view boltdb file interactively in your terminal

VERSION:
  2.0.1

USAGE:
  bolter [global options]

GLOBAL OPTIONS:
  --file FILE    boltdb FILE to view
  --help, -h     show help (default: false)
  --version, -v  print the version (default: false)
  
AUTHOR:
  Hasit Mistry <hasitnm@gmail.com>
COPYRIGHT:
  (c) 2016 Hasit Mistry
```

Go Version (installed from apt package):
go version go1.15.15 linux/amd64
