### PR TITLE
Fix the CLI author type to work with CLI 1.22

### DIFF
--- a/bolter.go
+++ b/bolter.go
@@ -42,8 +42,8 @@ COPYRIGHT:
 	app.Name = "bolter"
 	app.Usage = "view boltdb file interactively in your terminal"
 	app.Version = "2.0.1"
-	app.Authors = []*cli.Author{
-		&cli.Author{
+	app.Authors = []cli.Author{
+		{
 			Name:  "Hasit Mistry",
 			Email: "hasitnm@gmail.com",
 		},


### PR DESCRIPTION
This resolves:

```
../../.asdf/installs/golang/1.20.6/packages/pkg/mod/github.com/hasit/bolter@v0.0.0-20230502180907-68d80baa7620/bolter.go:45:16: cannot use []*cli.Author{…} (value of type []*cli.Author) as []cli.Author value in assignment
```
